### PR TITLE
Remove expo-router from Babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,9 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: [
-      'expo-router/babel',
-      'nativewind/babel',
-    ],
+    plugins: ['nativewind/babel'],
   };
 };


### PR DESCRIPTION
## Summary
- remove expo-router/babel plugin from Babel config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm start` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ace0493f408333b83b080f039fccd7